### PR TITLE
configure Docker file to connect to the database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,15 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libssh2-1-dev \
     tk-dev \
-    libssl1.0.0
+    libssl1.0.0 \
+    unixodbc \
+    freetds-bin \
+    tdsodbc
     
 RUN wget https://github.com/jgm/pandoc/releases/download/1.17.2/pandoc-1.17.2-1-amd64.deb
 RUN dpkg -i pandoc-1.17.2-1-amd64.deb  
 
-### configure connection to the database  
-    
-### install packages
-
-# install extra softwares
-sudo apt install unixodbc freetds-bin tdsodbc
-
-# configure properly the files
+### configure connection to the database
 
 # configuration of FreeTDS in the 'odbcinst.ini' file 
 RUN echo -e "[FreeTDS]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,41 @@ RUN apt-get update && apt-get install -y \
     libssl1.0.0
     
 RUN wget https://github.com/jgm/pandoc/releases/download/1.17.2/pandoc-1.17.2-1-amd64.deb
-RUN dpkg -i pandoc-1.17.2-1-amd64.deb    
+RUN dpkg -i pandoc-1.17.2-1-amd64.deb  
+
+### configure connection to the database  
     
 ### install packages
 
-# dependencies
+# install extra softwares
+sudo apt install unixodbc freetds-bin tdsodbc
+
+# configure properly the files
+
+# configuration of FreeTDS in the 'odbcinst.ini' file 
+RUN echo -e "[FreeTDS]
+Description = FreeTDS Driver v0.91
+Driver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
+Setup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so
+fileusage=1
+dontdlclose=1
+UsageCount=1" >> /etc/odbcinst.ini
+
+# append DSN configuration to the 'freetds.conf' file (path might be system-specific)
+RUN echo -e "[inbo-sql05-dev]
+host = 172.28.11.46
+port = 1435
+tds version = 4.2" >> /usr/local/etc/freetds.conf
+
+# append DSN configuration in 'odbc.ini' file
+RUN echo -e "[inbo-sql05-dev]
+Driver = FreeTDS
+Description = Development server
+Trace = No
+Server = 172.28.11.46
+Port = 1435
+Database = W0004_01_Waterbirds
+TDS_Version = 4.2" >> /etc/odbc.ini
 
 # package
 RUN R -e "install.packages(c('ggplot2', 'plotly', 'shiny'), repos = 'https://cloud.r-project.org')"


### PR DESCRIPTION
Note: To test the connection with `tsql`, I experienced some issue with the version of FreeTDS installed with 'apt install', similar to [this issue](https://stackoverflow.com/questions/34883036/remote-connection-to-sql-server-with-freetds-and-ipv6).
A higher version of FreeTDS could solve this issue.
For installation, the following code can be used:
```
wget ftp://ftp.freetds.org/pub/freetds/stable/freetds-1.00.54.tar.gz
tar -xzf freetds-1.00.54.tar.gz
cd freetds-1.00.54
./configure --prefix=/usr/local
make
sudo make install
make clean
```